### PR TITLE
Use image delimiter to enhance splash image.

### DIFF
--- a/PITCHME.md
+++ b/PITCHME.md
@@ -14,7 +14,7 @@ Note:
 - I work at Jailbreak, a free software development company, which adopted Elm in December for frontend development
 
 
----?image=assets/cbenz-piano.jpg
+---?image=assets/cbenz-piano.jpg&size=auto 90%
 
 Note:
 - pianist who loves playing in Jam Sessions

--- a/PITCHME.md
+++ b/PITCHME.md
@@ -13,9 +13,8 @@ Note:
 - I'm a professionnal developer who loves Elm, adopted it 1 year ago, professionnally and personnally
 - I work at Jailbreak, a free software development company, which adopted Elm in December for frontend development
 
----
 
-![](assets/cbenz-piano.jpg)
+---?image=assets/cbenz-piano.jpg
 
 Note:
 - pianist who loves playing in Jam Sessions


### PR DESCRIPTION
Hi Christophe, I came across your elm-europe-2017-talk presentation recently and really liked it. So much in fact that I plan to highlight your presentation in a new series on my blog called _GitPitch Presentation of the Day_. To give you some idea what you can expect, see the [inaugural post](https://medium.com/@gitpitch/gitpitch-presentation-of-the-day-1-db7987606d46) in this series here.

I've created this PR to make one small change to your `PITCHME.md` to better render the splash image on the second slide that shows you playing live with your band. Using an [image delimiter syntax](https://github.com/gitpitch/gitpitch/wiki/Image-Slides#background) rather than a plain Markdown image syntax can lend _more visual punch_ for these kinds of slides.

You can see how your presentation will be rendered if your accept this PR by opening [my fork of your presentation here](https://gitpitch.com/gitpitch/elm-europe-2017-talk).

Anyway, I love what you've created here and for the purposes of adding a little punch to your presentation while demonstrating best practices it would be great if you could accept this PR before I publish my next post.

Cheers,
David